### PR TITLE
Refactor os abstraction

### DIFF
--- a/Software/VolumeMaster-Windows/package.json
+++ b/Software/VolumeMaster-Windows/package.json
@@ -9,7 +9,8 @@
     "start": "electron .",
     "prebuild": "pyinstaller --onefile --noconsole --name VolumeMaster-Headless src/backend/main.pyw --distpath .",
     "build": "electron-builder",
-    "dist": "electron-builder"
+    "dist": "electron-builder",
+    "build:mac": "electron-builder --mac dir"
   },
   "build": {
     "appId": "com.williamspalding.volumemaster",
@@ -25,18 +26,22 @@
       "!**/node_modules/@emnapi",
       "!**/node_modules/@esbuild"
     ],
-    "extraResources": [
-      {
-        "from": "VolumeMaster-Headless.exe",
-        "to": "VolumeMaster-Headless.exe"
-      }
-    ],
     "directories": {
       "output": "release"
     },
     "win": {
       "target": "nsis",
-      "icon": "src/assets/icons/icon.ico"
+      "icon": "src/assets/icons/icon.ico",
+      "extraResources": [
+        {
+          "from": "VolumeMaster-Headless.exe",
+          "to": "VolumeMaster-Headless.exe"
+        }
+      ]
+    },
+    "mac": {
+      "target": "dir",
+      "icon": "src/assets/icons/icon.icns"
     },
     "nsis": {
       "oneClick": false,
@@ -47,12 +52,14 @@
     "@tailwindcss/cli": "^4.2.2",
     "@tailwindcss/postcss": "^4.2.2",
     "icojs": "^0.20.1",
-    "naudiodon": "^2.3.6",
     "ps-list": "^8.1.1",
     "serialport": "^13.0.0",
     "tree-kill": "^1.2.2",
     "x64": "^1.0.0",
     "yaml": "^2.8.3"
+  },
+  "optionalDependencies": {
+    "naudiodon": "^2.3.6"
   },
   "devDependencies": {
     "@electron/fuses": "^1.8.0",

--- a/Software/VolumeMaster-Windows/package.json
+++ b/Software/VolumeMaster-Windows/package.json
@@ -10,7 +10,7 @@
     "prebuild": "pyinstaller --onefile --noconsole --name VolumeMaster-Headless src/backend/main.pyw --distpath .",
     "build": "electron-builder",
     "dist": "electron-builder",
-    "build:mac": "electron-builder --mac dir"
+    "build:mac": "electron-rebuild && electron-builder --mac dir"
   },
   "build": {
     "appId": "com.williamspalding.volumemaster",
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@electron/fuses": "^1.8.0",
+    "@electron/rebuild": "^3.7.1",
     "autoprefixer": "^10.4.27",
     "electron": "^37.2.0",
     "electron-builder": "^26.8.1",

--- a/Software/VolumeMaster-Windows/package.json
+++ b/Software/VolumeMaster-Windows/package.json
@@ -10,7 +10,7 @@
     "prebuild": "pyinstaller --onefile --noconsole --name VolumeMaster-Headless src/backend/main.pyw --distpath .",
     "build": "electron-builder",
     "dist": "electron-builder",
-    "build:mac": "electron-rebuild && electron-builder --mac dir"
+    "build:mac": "electron-builder --mac dir"
   },
   "build": {
     "appId": "com.williamspalding.volumemaster",
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@electron/fuses": "^1.8.0",
-    "@electron/rebuild": "^3.7.1",
     "autoprefixer": "^10.4.27",
     "electron": "^37.2.0",
     "electron-builder": "^26.8.1",

--- a/Software/VolumeMaster-Windows/src/main.js
+++ b/Software/VolumeMaster-Windows/src/main.js
@@ -7,6 +7,7 @@ if (process.platform === 'win32') {
   app.commandLine.appendSwitch('disable-features', 'AllowNativeOleApiForDragDrop');
 }
 
+const platform = require('./main/platform');
 const { createWindow } = require('./main/window');
 const { createTray } = require('./main/tray');
 const { registerIpcHandlers } = require('./main/ipc-handlers');
@@ -28,9 +29,7 @@ if (!gotLock) {
 
   app.whenReady().then(() => {
     // Kill any headless processes left over from a previous crash (will-quit never fired)
-    try {
-      require('child_process').execSync('taskkill /F /IM VolumeMaster-Headless.exe', { stdio: 'ignore' });
-    } catch { /* none running — that's fine */ }
+    platform.forceKillAllBackends();
 
     deviceManager.migrateIfNeeded();
     registerIpcHandlers();

--- a/Software/VolumeMaster-Windows/src/main/backend-process.js
+++ b/Software/VolumeMaster-Windows/src/main/backend-process.js
@@ -1,12 +1,10 @@
-const path = require('path');
 const { spawn } = require('child_process');
 const treeKill = require('tree-kill');
 
+const platform = require('./platform');
 const { setTrayImageNormal, setTrayImageCrashed } = require('./tray');
 const deviceManager = require('./device-manager');
 const { handleVolumeChange } = require('./notification-window');
-
-const headlessExePath = path.join(process.resourcesPath, 'VolumeMaster-Headless.exe');
 
 // Map<deviceId, { process, retryTimeout }>
 const backends = new Map();
@@ -49,7 +47,7 @@ function startBackend(deviceId, deviceDir) {
   }
 
   console.log(`[${deviceId}] Starting backend...`);
-  const proc = spawn(headlessExePath, [], {
+  const proc = spawn(platform.getBackendBinaryPath(), [], {
     detached: false,
     stdio: 'pipe',
     shell: false,
@@ -145,11 +143,7 @@ async function killAllBackends() {
   const ids = [...backends.keys()];
   await Promise.all(ids.map((id) => killBackend(id)));
   // Synchronous fallback: force-kill any instances that slipped through
-  try {
-    require('child_process').execSync('taskkill /F /IM VolumeMaster-Headless.exe', { stdio: 'ignore' });
-  } catch {
-    // Throws if no processes found — that's fine
-  }
+  platform.forceKillAllBackends();
 }
 
 function getBackendProcess(deviceId) {

--- a/Software/VolumeMaster-Windows/src/main/icon-service.js
+++ b/Software/VolumeMaster-Windows/src/main/icon-service.js
@@ -1,12 +1,8 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const util = require('util');
 
-const exec = util.promisify(require('child_process').exec);
-
-// In-memory cache: exe name → resolved full path, survives across calls
-const exePathCache = new Map();
+const platform = require('./platform');
 
 function cacheDir() {
   return path.join(require('electron').app.getPath('userData'), 'iconCache');
@@ -42,28 +38,6 @@ function saveIconToCache(key, nativeImage) {
   }
 }
 
-async function findRunningProcessExePath(exeName) {
-  // Check in-memory cache first to avoid repeated PowerShell spawns
-  if (exePathCache.has(exeName)) {
-    return exePathCache.get(exeName);
-  }
-
-  try {
-    const baseName = path.basename(exeName, '.exe');
-    const cmd = `powershell -NoProfile -NonInteractive -Command "Get-Process -Name '${baseName}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path -First 1"`;
-    const { stdout } = await exec(cmd, { encoding: 'utf8', timeout: 5000 });
-    const resolved = stdout.trim();
-    if (resolved && fs.existsSync(resolved)) {
-      exePathCache.set(exeName, resolved);
-      return resolved;
-    }
-  } catch {
-    // Process not found or PowerShell timed out
-  }
-
-  return null;
-}
-
 async function getAppIcon(exeNameOrPath) {
   if (!exeNameOrPath || typeof exeNameOrPath !== 'string') return null;
 
@@ -73,12 +47,12 @@ async function getAppIcon(exeNameOrPath) {
   const cached = loadIconFromCache(cacheKey);
   if (cached) return cached;
 
-  // Resolve to an absolute path — direct path skips PowerShell entirely
+  // Resolve to an absolute path — direct path skips platform lookup entirely
   let resolvedPath;
   if (path.isAbsolute(exeNameOrPath) && fs.existsSync(exeNameOrPath)) {
     resolvedPath = exeNameOrPath;
   } else {
-    resolvedPath = await findRunningProcessExePath(exeNameOrPath);
+    resolvedPath = await platform.findProcessExePath(exeNameOrPath);
   }
 
   if (!resolvedPath) return null;
@@ -97,4 +71,4 @@ async function getAppIcon(exeNameOrPath) {
   }
 }
 
-module.exports = { getAppIcon, findRunningProcessExePath };
+module.exports = { getAppIcon };

--- a/Software/VolumeMaster-Windows/src/main/ipc-handlers.js
+++ b/Software/VolumeMaster-Windows/src/main/ipc-handlers.js
@@ -1,13 +1,10 @@
-const util = require('util');
 const { SerialPort } = require('serialport');
-const portAudio = require('naudiodon');
 
+const platform = require('./platform');
 const { loadConfig, saveConfig, cloneConfigSnapshot } = require('./config-store');
 const { getAppIcon } = require('./icon-service');
 const { startBackend, killBackend, getBackendProcess } = require('./backend-process');
 const deviceManager = require('./device-manager');
-
-const exec = util.promisify(require('child_process').exec);
 
 /** Resolves the deviceId and deviceDir for the window that sent an IPC event. */
 function getDeviceContext(event) {
@@ -54,30 +51,7 @@ function registerIpcHandlers() {
 
   ipcMain.handle('list-processes', async () => {
     try {
-      const { stdout } = await exec(
-        `powershell -NoProfile -Command "Get-Process | Select-Object ProcessName, MainWindowTitle"`,
-        { encoding: 'utf8' }
-      );
-
-      const seen = new Map();
-      stdout
-        .split(/\r?\n/)
-        .map((l) => l.trim())
-        .filter(Boolean)
-        .slice(2)
-        .forEach((line) => {
-          const parts = line.split(/\s{2,}/);
-          const name = parts[0];
-          const windowTitle = parts[1] || '';
-          const exeName = name.endsWith('.exe') ? name : `${name}.exe`;
-
-          const existing = seen.get(exeName);
-          if (!existing || (!existing.isGUI && windowTitle !== '')) {
-            seen.set(exeName, { name: exeName, isGUI: windowTitle !== '' });
-          }
-        });
-
-      return [...seen.values()];
+      return await platform.getProcessList();
     } catch (err) {
       console.error('Failed to list processes:', err);
       return [];
@@ -180,11 +154,7 @@ function registerIpcHandlers() {
 
   ipcMain.handle('list-input-devices', async () => {
     try {
-      const devices = portAudio.getDevices();
-      const cleanDevices = devices
-        .filter((d) => d.maxInputChannels > 0 && d.hostAPIName === 'Windows WASAPI')
-        .map((d) => d.name);
-      return [...new Set(cleanDevices)];
+      return await platform.getAudioInputDevices();
     } catch (err) {
       console.error('Failed to list input devices:', err);
       return [];

--- a/Software/VolumeMaster-Windows/src/main/platform/index.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * Platform abstraction layer.
+ * Loads the correct OS-specific implementation based on process.platform.
+ *
+ * Each platform module must implement:
+ *   getProcessList()         → Promise<Array<{name: string, isGUI: boolean}>>
+ *   getAudioInputDevices()   → Promise<string[]>
+ *   findProcessExePath(exe)  → Promise<string|null>
+ *   getBackendBinaryPath()   → string
+ *   forceKillAllBackends()   → void
+ */
+
+const platformMap = {
+  win32: './windows',
+  darwin: './macos',
+  // linux: './linux',   // future
+};
+
+const impl = platformMap[process.platform];
+if (!impl) {
+  throw new Error(`Unsupported platform: ${process.platform}`);
+}
+
+module.exports = require(impl);

--- a/Software/VolumeMaster-Windows/src/main/platform/macos.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/macos.js
@@ -1,69 +1,81 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
 
-/**
- * macOS platform implementation.
- * Audio input devices and process icon extraction are stubs until
- * a native macOS backend (Swift/Rust) is implemented.
- */
+const execFileAsync = promisify(execFile);
 
 /**
  * Returns a list of running processes using `ps`.
  * @returns {Promise<Array<{name: string, isGUI: boolean}>>}
  */
 async function getProcessList() {
-  const { execFile } = require('child_process');
-  const { promisify } = require('util');
-  const execFileAsync = promisify(execFile);
-
   const { stdout } = await execFileAsync('ps', ['-eo', 'comm']);
   const seen = new Set();
 
   stdout
     .split('\n')
-    .map((l) => l.trim())
+    .map((l) => path.basename(l.trim()))
     .filter(Boolean)
     .slice(1) // skip header
-    .forEach((name) => {
-      const base = path.basename(name);
-      if (base) seen.add(base);
-    });
+    .forEach((name) => seen.add(name));
 
   // macOS processes don't have a reliable "isGUI" flag from ps — default false
   return [...seen].map((name) => ({ name, isGUI: false }));
 }
 
 /**
- * Returns audio input device names.
- * Stub — returns empty until Swift/CoreAudio backend is implemented.
+ * Returns audio input device names via CoreAudio (naudiodon/PortAudio).
  * @returns {Promise<string[]>}
  */
 async function getAudioInputDevices() {
-  return [];
+  const portAudio = require('naudiodon');
+  const devices = portAudio.getDevices();
+  const cleanDevices = devices
+    .filter((d) => d.maxInputChannels > 0 && d.hostAPIName === 'Core Audio')
+    .map((d) => d.name);
+  return [...new Set(cleanDevices)];
 }
 
 /**
- * Resolves a process name to its executable path.
- * Uses `which` for PATH-based lookups; returns null for unknown processes.
+ * Resolves a process name to its .app bundle path (for icon extraction).
+ * Tries Spotlight (mdfind) first, then falls back to common app directories.
  * @param {string} exeName
  * @returns {Promise<string|null>}
  */
 async function findProcessExePath(exeName) {
+  // Strip .exe suffix if present (Windows process names copied from config)
+  const baseName = path.basename(exeName, '.exe');
+
+  // Spotlight lookup — finds installed .app bundles by their executable name
   try {
-    const { execFile } = require('child_process');
-    const { promisify } = require('util');
-    const execFileAsync = promisify(execFile);
-    const { stdout } = await execFileAsync('which', [exeName]);
-    return stdout.trim() || null;
+    const { stdout } = await execFileAsync(
+      'mdfind',
+      [`kMDItemCFBundleExecutable == "${baseName}"`],
+      { timeout: 3000 }
+    );
+    const appPath = stdout.split('\n').find((l) => l.trim().endsWith('.app'));
+    if (appPath && fs.existsSync(appPath.trim())) return appPath.trim();
   } catch {
-    return null;
+    // Spotlight unavailable
   }
+
+  // Fall back to common install locations
+  const searchDirs = ['/Applications', path.join(os.homedir(), 'Applications')];
+  for (const dir of searchDirs) {
+    const appBundle = path.join(dir, `${baseName}.app`);
+    if (fs.existsSync(appBundle)) return appBundle;
+  }
+
+  return null;
 }
 
 /**
  * Returns the path to the macOS backend binary.
- * Stub — returns null until a macOS backend is built.
+ * Stub — returns null until the Swift backend is built.
  * @returns {string|null}
  */
 function getBackendBinaryPath() {
@@ -72,10 +84,10 @@ function getBackendBinaryPath() {
 
 /**
  * Force-kills all backend processes.
- * Stub — no-op until the macOS backend binary name is known.
+ * Stub — no-op until the Swift backend binary name is known.
  */
 function forceKillAllBackends() {
-  // no-op for now
+  // no-op until Swift backend exists
 }
 
 module.exports = {

--- a/Software/VolumeMaster-Windows/src/main/platform/macos.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/macos.js
@@ -4,8 +4,7 @@ const path = require('path');
 
 /**
  * macOS platform implementation.
- * Audio input devices and process icon extraction are stubs until
- * a native macOS backend (Swift/Rust) is implemented.
+ * Audio input devices and process icon extraction are stubs
  */
 
 /**
@@ -30,13 +29,13 @@ async function getProcessList() {
       if (base) seen.add(base);
     });
 
-  // macOS processes don't have a reliable "isGUI" flag from ps — default false
+  // macOS processes don't have a reliable "isGUI" flag from ps — default false (will need some way around this...)
   return [...seen].map((name) => ({ name, isGUI: false }));
 }
 
 /**
  * Returns audio input device names.
- * Stub — returns empty until Swift/CoreAudio backend is implemented.
+ * Stub — returns empty 
  * @returns {Promise<string[]>}
  */
 async function getAudioInputDevices() {
@@ -46,7 +45,7 @@ async function getAudioInputDevices() {
 /**
  * Resolves a process name to its executable path.
  * Uses `which` for PATH-based lookups; returns null for unknown processes.
- * @param {string} exeName
+ * Not sure if this is needed for MacOS, but it was part of the Windows implementation so included for parity. depends how the backend is implemented
  * @returns {Promise<string|null>}
  */
 async function findProcessExePath(exeName) {

--- a/Software/VolumeMaster-Windows/src/main/platform/macos.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/macos.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const path = require('path');
+
+/**
+ * macOS platform implementation.
+ * Audio input devices and process icon extraction are stubs until
+ * a native macOS backend (Swift/Rust) is implemented.
+ */
+
+/**
+ * Returns a list of running processes using `ps`.
+ * @returns {Promise<Array<{name: string, isGUI: boolean}>>}
+ */
+async function getProcessList() {
+  const { execFile } = require('child_process');
+  const { promisify } = require('util');
+  const execFileAsync = promisify(execFile);
+
+  const { stdout } = await execFileAsync('ps', ['-eo', 'comm']);
+  const seen = new Set();
+
+  stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .slice(1) // skip header
+    .forEach((name) => {
+      const base = path.basename(name);
+      if (base) seen.add(base);
+    });
+
+  // macOS processes don't have a reliable "isGUI" flag from ps — default false
+  return [...seen].map((name) => ({ name, isGUI: false }));
+}
+
+/**
+ * Returns audio input device names.
+ * Stub — returns empty until Swift/CoreAudio backend is implemented.
+ * @returns {Promise<string[]>}
+ */
+async function getAudioInputDevices() {
+  return [];
+}
+
+/**
+ * Resolves a process name to its executable path.
+ * Uses `which` for PATH-based lookups; returns null for unknown processes.
+ * @param {string} exeName
+ * @returns {Promise<string|null>}
+ */
+async function findProcessExePath(exeName) {
+  try {
+    const { execFile } = require('child_process');
+    const { promisify } = require('util');
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync('which', [exeName]);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the path to the macOS backend binary.
+ * Stub — returns null until a macOS backend is built.
+ * @returns {string|null}
+ */
+function getBackendBinaryPath() {
+  return null;
+}
+
+/**
+ * Force-kills all backend processes.
+ * Stub — no-op until the macOS backend binary name is known.
+ */
+function forceKillAllBackends() {
+  // no-op for now
+}
+
+module.exports = {
+  getProcessList,
+  getAudioInputDevices,
+  findProcessExePath,
+  getBackendBinaryPath,
+  forceKillAllBackends,
+};

--- a/Software/VolumeMaster-Windows/src/main/platform/macos.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/macos.js
@@ -1,81 +1,69 @@
 'use strict';
 
 const path = require('path');
-const fs = require('fs');
-const os = require('os');
-const { execFile } = require('child_process');
-const { promisify } = require('util');
 
-const execFileAsync = promisify(execFile);
+/**
+ * macOS platform implementation.
+ * Audio input devices and process icon extraction are stubs until
+ * a native macOS backend (Swift/Rust) is implemented.
+ */
 
 /**
  * Returns a list of running processes using `ps`.
  * @returns {Promise<Array<{name: string, isGUI: boolean}>>}
  */
 async function getProcessList() {
+  const { execFile } = require('child_process');
+  const { promisify } = require('util');
+  const execFileAsync = promisify(execFile);
+
   const { stdout } = await execFileAsync('ps', ['-eo', 'comm']);
   const seen = new Set();
 
   stdout
     .split('\n')
-    .map((l) => path.basename(l.trim()))
+    .map((l) => l.trim())
     .filter(Boolean)
     .slice(1) // skip header
-    .forEach((name) => seen.add(name));
+    .forEach((name) => {
+      const base = path.basename(name);
+      if (base) seen.add(base);
+    });
 
   // macOS processes don't have a reliable "isGUI" flag from ps — default false
   return [...seen].map((name) => ({ name, isGUI: false }));
 }
 
 /**
- * Returns audio input device names via CoreAudio (naudiodon/PortAudio).
+ * Returns audio input device names.
+ * Stub — returns empty until Swift/CoreAudio backend is implemented.
  * @returns {Promise<string[]>}
  */
 async function getAudioInputDevices() {
-  const portAudio = require('naudiodon');
-  const devices = portAudio.getDevices();
-  const cleanDevices = devices
-    .filter((d) => d.maxInputChannels > 0 && d.hostAPIName === 'Core Audio')
-    .map((d) => d.name);
-  return [...new Set(cleanDevices)];
+  return [];
 }
 
 /**
- * Resolves a process name to its .app bundle path (for icon extraction).
- * Tries Spotlight (mdfind) first, then falls back to common app directories.
+ * Resolves a process name to its executable path.
+ * Uses `which` for PATH-based lookups; returns null for unknown processes.
  * @param {string} exeName
  * @returns {Promise<string|null>}
  */
 async function findProcessExePath(exeName) {
-  // Strip .exe suffix if present (Windows process names copied from config)
-  const baseName = path.basename(exeName, '.exe');
-
-  // Spotlight lookup — finds installed .app bundles by their executable name
   try {
-    const { stdout } = await execFileAsync(
-      'mdfind',
-      [`kMDItemCFBundleExecutable == "${baseName}"`],
-      { timeout: 3000 }
-    );
-    const appPath = stdout.split('\n').find((l) => l.trim().endsWith('.app'));
-    if (appPath && fs.existsSync(appPath.trim())) return appPath.trim();
+    const { execFile } = require('child_process');
+    const { promisify } = require('util');
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync('which', [exeName]);
+    return stdout.trim() || null;
   } catch {
-    // Spotlight unavailable
+    return null;
   }
-
-  // Fall back to common install locations
-  const searchDirs = ['/Applications', path.join(os.homedir(), 'Applications')];
-  for (const dir of searchDirs) {
-    const appBundle = path.join(dir, `${baseName}.app`);
-    if (fs.existsSync(appBundle)) return appBundle;
-  }
-
-  return null;
 }
 
 /**
  * Returns the path to the macOS backend binary.
- * Stub — returns null until the Swift backend is built.
+ * Stub — returns null until a macOS backend is built.
  * @returns {string|null}
  */
 function getBackendBinaryPath() {
@@ -84,10 +72,10 @@ function getBackendBinaryPath() {
 
 /**
  * Force-kills all backend processes.
- * Stub — no-op until the Swift backend binary name is known.
+ * Stub — no-op until the macOS backend binary name is known.
  */
 function forceKillAllBackends() {
-  // no-op until Swift backend exists
+  // no-op for now
 }
 
 module.exports = {

--- a/Software/VolumeMaster-Windows/src/main/platform/windows.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/windows.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+// In-memory cache: exe name → resolved full path, survives across calls
+const exePathCache = new Map();
+
+/**
+ * Returns a list of running processes.
+ * @returns {Promise<Array<{name: string, isGUI: boolean}>>}
+ */
+async function getProcessList() {
+  const { stdout } = await exec(
+    `powershell -NoProfile -Command "Get-Process | Select-Object ProcessName, MainWindowTitle"`,
+    { encoding: 'utf8' }
+  );
+
+  const seen = new Map();
+  stdout
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .slice(2)
+    .forEach((line) => {
+      const parts = line.split(/\s{2,}/);
+      const name = parts[0];
+      const windowTitle = parts[1] || '';
+      const exeName = name.endsWith('.exe') ? name : `${name}.exe`;
+
+      const existing = seen.get(exeName);
+      if (!existing || (!existing.isGUI && windowTitle !== '')) {
+        seen.set(exeName, { name: exeName, isGUI: windowTitle !== '' });
+      }
+    });
+
+  return [...seen.values()];
+}
+
+/**
+ * Returns a list of audio input device names via Windows WASAPI.
+ * @returns {Promise<string[]>}
+ */
+async function getAudioInputDevices() {
+  const portAudio = require('naudiodon');
+  const devices = portAudio.getDevices();
+  const cleanDevices = devices
+    .filter((d) => d.maxInputChannels > 0 && d.hostAPIName === 'Windows WASAPI')
+    .map((d) => d.name);
+  return [...new Set(cleanDevices)];
+}
+
+/**
+ * Resolves a running process exe name to its full disk path via PowerShell.
+ * Returns null if the process is not found or not running.
+ * @param {string} exeName
+ * @returns {Promise<string|null>}
+ */
+async function findProcessExePath(exeName) {
+  if (exePathCache.has(exeName)) {
+    return exePathCache.get(exeName);
+  }
+
+  try {
+    const baseName = path.basename(exeName, '.exe');
+    const cmd = `powershell -NoProfile -NonInteractive -Command "Get-Process -Name '${baseName}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path -First 1"`;
+    const { stdout } = await exec(cmd, { encoding: 'utf8', timeout: 5000 });
+    const resolved = stdout.trim();
+    if (resolved && fs.existsSync(resolved)) {
+      exePathCache.set(exeName, resolved);
+      return resolved;
+    }
+  } catch {
+    // Process not found or PowerShell timed out
+  }
+
+  return null;
+}
+
+/**
+ * Returns the absolute path to the platform-specific backend binary.
+ * @returns {string}
+ */
+function getBackendBinaryPath() {
+  return path.join(process.resourcesPath, 'VolumeMaster-Headless.exe');
+}
+
+/**
+ * Force-kills all backend processes. Used on startup and as a fallback on quit.
+ * Safe to call even if no processes are running.
+ */
+function forceKillAllBackends() {
+  try {
+    require('child_process').execSync('taskkill /F /IM VolumeMaster-Headless.exe', { stdio: 'ignore' });
+  } catch {
+    // Throws if no matching processes — that's fine
+  }
+}
+
+module.exports = {
+  getProcessList,
+  getAudioInputDevices,
+  findProcessExePath,
+  getBackendBinaryPath,
+  forceKillAllBackends,
+};


### PR DESCRIPTION
Added abstraction layer to handle cross platform support. 
Added macos stub functions to guide future dev.

To build on mac:
`npm run build:mac`

MacOS support is not finished and backend still needs to be made. 
