### PR TITLE
Adjust UI to accommodate for different window sizing, and rename programs to appropriate names

### DIFF
--- a/Software/VolumeMaster-Windows/src/main/platform/index.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/index.js
@@ -5,7 +5,7 @@
  * Loads the correct OS-specific implementation based on process.platform.
  *
  * Each platform module must implement:
- *   getProcessList()         → Promise<Array<{name: string, isGUI: boolean}>>
+ *   getProcessList()         → Promise<Array<{name: string, title: string, path: string|null, isGUI: boolean}>>
  *   getAudioInputDevices()   → Promise<string[]>
  *   findProcessExePath(exe)  → Promise<string|null>
  *   getBackendBinaryPath()   → string

--- a/Software/VolumeMaster-Windows/src/main/platform/macos.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/macos.js
@@ -9,7 +9,7 @@ const path = require('path');
 
 /**
  * Returns a list of running processes using `ps`.
- * @returns {Promise<Array<{name: string, isGUI: boolean}>>}
+ * @returns {Promise<Array<{name: string, title: string, path: string|null, isGUI: boolean}>>}
  */
 async function getProcessList() {
   const { execFile } = require('child_process');
@@ -30,7 +30,7 @@ async function getProcessList() {
     });
 
   // macOS processes don't have a reliable "isGUI" flag from ps — default false (will need some way around this...)
-  return [...seen].map((name) => ({ name, isGUI: false }));
+  return [...seen].map((name) => ({ name, title: name, path: null, isGUI: false }));
 }
 
 /**

--- a/Software/VolumeMaster-Windows/src/main/platform/windows.js
+++ b/Software/VolumeMaster-Windows/src/main/platform/windows.js
@@ -8,33 +8,63 @@ const exec = util.promisify(require('child_process').exec);
 // In-memory cache: exe name → resolved full path, survives across calls
 const exePathCache = new Map();
 
+function normalizeProcessTitle(windowTitle, processName) {
+  const fallback = processName.endsWith('.exe') ? processName : `${processName}.exe`;
+  if (!windowTitle) return fallback;
+
+  const separators = [' - ', ' — ', ' | '];
+  for (const separator of separators) {
+    const parts = windowTitle
+      .split(separator)
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (parts.length > 1) {
+      return parts[parts.length - 1];
+    }
+  }
+
+  return windowTitle;
+}
+
 /**
- * Returns a list of running processes.
- * @returns {Promise<Array<{name: string, isGUI: boolean}>>}
+ * Returns a list of running processes and their friendly titles by invoking PowerShell to query the system.
+ * Each entry includes:
+ *   - name: the executable name (e.g. "chrome.exe")
+ *   - title: a user-friendly title derived from the window title or process name
+ * @returns {Promise<Array<{name: string, title: string, path: string|null, isGUI: boolean}>>}
  */
 async function getProcessList() {
   const { stdout } = await exec(
-    `powershell -NoProfile -Command "Get-Process | Select-Object ProcessName, MainWindowTitle"`,
-    { encoding: 'utf8' }
+    `powershell -NoProfile -Command "Get-Process | Select-Object ProcessName, MainWindowTitle, Path | ConvertTo-Json -Depth 2"`,
+    { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 } // maxBuffer increased to handle large process lists with long titles/paths without truncation
   );
 
-  const seen = new Map();
-  stdout
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter(Boolean)
-    .slice(2)
-    .forEach((line) => {
-      const parts = line.split(/\s{2,}/);
-      const name = parts[0];
-      const windowTitle = parts[1] || '';
-      const exeName = name.endsWith('.exe') ? name : `${name}.exe`;
+  const raw = stdout.trim();
+  if (!raw) return [];
 
-      const existing = seen.get(exeName);
-      if (!existing || (!existing.isGUI && windowTitle !== '')) {
-        seen.set(exeName, { name: exeName, isGUI: windowTitle !== '' });
-      }
-    });
+  const parsed = JSON.parse(raw);
+  const rows = Array.isArray(parsed) ? parsed : [parsed];
+  const seen = new Map();
+
+  rows.forEach((row) => {
+    const processName = typeof row?.ProcessName === 'string' ? row.ProcessName.trim() : '';
+    if (!processName) return;
+
+    const exeName = processName.endsWith('.exe') ? processName : `${processName}.exe`;
+    const windowTitle = typeof row?.MainWindowTitle === 'string' ? row.MainWindowTitle.trim() : '';
+    const resolvedPath = typeof row?.Path === 'string' && row.Path.trim() ? row.Path.trim() : null;
+    const nextEntry = {
+      name: exeName,
+      title: normalizeProcessTitle(windowTitle, processName),
+      path: resolvedPath,
+      isGUI: windowTitle !== '',
+    };
+
+    const existing = seen.get(exeName);
+    if (!existing || (!existing.isGUI && nextEntry.isGUI)) {
+      seen.set(exeName, nextEntry);
+    }
+  });
 
   return [...seen.values()];
 }

--- a/Software/VolumeMaster-Windows/src/main/window.js
+++ b/Software/VolumeMaster-Windows/src/main/window.js
@@ -15,8 +15,10 @@ function createWindow(deviceId) {
       })();
 
   const win = new BrowserWindow({
-    width: 1000,
-    height: 700,
+    width: 1200,
+    height: 800,
+    minWidth: 700,
+    minHeight: 700,
     ...positionOpts,
     title,
     icon: path.join(__dirname, '..', 'assets', 'icons', 'icon.ico'),

--- a/Software/VolumeMaster-Windows/src/renderer.html
+++ b/Software/VolumeMaster-Windows/src/renderer.html
@@ -52,6 +52,29 @@
       #alertContainer > * {
         pointer-events: auto;
       }
+      /* Responsive icon transition: fade and collapse icon under 1000px */
+      .responsive-icon {
+        display: inline-block;
+        width: 40px;
+        height: 40px;
+        min-width: 40px;
+        min-height: 40px;
+        opacity: 1;
+        overflow: hidden;
+        transition: opacity 180ms ease, width 180ms ease, margin 180ms ease, height 180ms ease;
+        flex-shrink: 0;
+      }
+      .app-card { gap: 1rem; }
+      @media (max-width: 1000px) {
+        .responsive-icon {
+          opacity: 0;
+          width: 0 !important;
+          min-width: 0 !important;
+          margin-right: 0 !important;
+          pointer-events: none;
+        }
+        .app-card { gap: 0.25rem; }
+      }
     </style>
   </head>
 

--- a/Software/VolumeMaster-Windows/src/renderer/mappings.js
+++ b/Software/VolumeMaster-Windows/src/renderer/mappings.js
@@ -362,7 +362,7 @@ function createAppCard(app, knobId) {
 
   const icon = document.createElement('img');
   icon.alt = app;
-  icon.className = 'w-10 h-10 rounded sm:hidden md:block';
+  icon.className = 'w-10 h-10 rounded responsive-icon shrink-0';
   icon.draggable = false;
   card.classList.add('app-card');
 
@@ -371,11 +371,11 @@ function createAppCard(app, knobId) {
 
   const label = document.createElement('div');
   label.textContent = display.title || sanitizeAppName(app);
-  label.className = 'text-lg font-medium shrink text-wrap';
+  label.className = 'text-lg font-medium break-words';
 
   const subtitle = document.createElement('div');
   subtitle.textContent = display.subtitle || app;
-  subtitle.className = 'text-xs text-slate-500 truncate';
+  subtitle.className = 'text-xs text-slate-500 break-words';
 
   textWrap.append(label, subtitle);
   card.append(icon, textWrap);

--- a/Software/VolumeMaster-Windows/src/renderer/mappings.js
+++ b/Software/VolumeMaster-Windows/src/renderer/mappings.js
@@ -1,6 +1,6 @@
 import { state } from './state.js';
 import { saveConfigAndSync } from './config-sync.js';
-import { sanitizeAppName } from './utils.js';
+import { getProcessDisplayInfo, sanitizeAppName } from './utils.js';
 import { getVMLabel, isVMItem, vmItemId } from './voicemeeter.js';
 
 // Live volume levels keyed by knobId string
@@ -354,6 +354,7 @@ function createEmptyMessage() {
 }
 
 function createAppCard(app, knobId) {
+  const display = getProcessDisplayInfo(app);
   const card = document.createElement('div');
   card.className =
     'flex items-center gap-4 mb-3 p-3 rounded border border-gray-300 hover:bg-red-100 cursor-pointer transition overflow-hidden';
@@ -365,11 +366,19 @@ function createAppCard(app, knobId) {
   icon.draggable = false;
   card.classList.add('app-card');
 
-  const label = document.createElement('div');
-  label.textContent = sanitizeAppName(app);
-  label.className = 'text-lg font-medium shrink capitalize text-wrap';
+  const textWrap = document.createElement('div');
+  textWrap.className = 'flex min-w-0 flex-col';
 
-  card.append(icon, label);
+  const label = document.createElement('div');
+  label.textContent = display.title || sanitizeAppName(app);
+  label.className = 'text-lg font-medium shrink text-wrap';
+
+  const subtitle = document.createElement('div');
+  subtitle.textContent = display.subtitle || app;
+  subtitle.className = 'text-xs text-slate-500 truncate';
+
+  textWrap.append(label, subtitle);
+  card.append(icon, textWrap);
 
   card.onclick = async () => {
     await removeAppFromKnob(knobId, app);

--- a/Software/VolumeMaster-Windows/src/renderer/sources.js
+++ b/Software/VolumeMaster-Windows/src/renderer/sources.js
@@ -1,6 +1,7 @@
-import { state } from './state.js';
-import { sanitizeAppName } from './utils.js';
 import { VM_CHANNELS } from './voicemeeter.js';
+import { state } from './state.js';
+
+const DEFAULT_PROCESS_ICON = 'assets/icons/default.png';
 
 export async function loadProcessList() {
   state.runningProcesses = await window.api.listProcesses();
@@ -40,17 +41,59 @@ export function renderProcessSearch() {
     state.runningProcesses
       .filter((proc) => {
         if (!proc || !proc.name) return false;
-        const matchesSearch = proc.name.toLowerCase().includes(searchFilter);
+        const title = typeof proc.title === 'string' ? proc.title : '';
+        const matchesSearch =
+          proc.name.toLowerCase().includes(searchFilter) || title.toLowerCase().includes(searchFilter);
         const matchesType = typeFilter === 'all' || (typeFilter === 'gui' && proc.isGUI);
         return matchesSearch && matchesType;
       })
       .forEach((proc) => {
         const item = document.createElement('div');
-        item.textContent = sanitizeAppName(proc.name);
         item.id = `process-item-${proc.name}`;
         item.className =
-          'px-2 py-1 bg-slate-700 text-indigo-200 rounded cursor-move hover:bg-indigo-600 transition whitespace-nowrap capitalize max-h-8';
+          'flex items-center gap-2 px-2 py-1 bg-slate-700 text-indigo-200 rounded cursor-move hover:bg-indigo-600 transition overflow-hidden max-h-12 min-w-0';
         item.setAttribute('draggable', 'true');
+
+        const icon = document.createElement('img');
+        const processTitle = typeof proc.title === 'string' && proc.title.trim() ? proc.title.trim() : proc.name;
+        icon.alt = processTitle;
+        icon.className = 'w-4 h-4 shrink-0 rounded';
+        icon.draggable = false;
+        icon.src = DEFAULT_PROCESS_ICON;
+
+        const textWrap = document.createElement('div');
+        textWrap.className = 'flex flex-col min-w-0 leading-tight';
+
+        const title = document.createElement('span');
+        title.className = 'text-[10px] font-semibold truncate';
+        title.textContent = processTitle;
+
+        const subtitle = document.createElement('span');
+        subtitle.className = 'text-xs text-slate-300 truncate';
+        subtitle.textContent = proc.name;
+
+        textWrap.append(title, subtitle);
+        item.append(icon, textWrap);
+
+        const iconKey = proc.path || proc.name;
+        const cachedIcon = state.iconCache.get(iconKey) || state.iconCache.get(proc.name);
+        if (cachedIcon) {
+          icon.src = cachedIcon;
+        } else {
+          window.api
+            .getAppIcon(iconKey)
+            .then((src) => {
+              const resolved = src || DEFAULT_PROCESS_ICON;
+              state.iconCache.set(iconKey, resolved);
+              if (iconKey === proc.name) {
+                state.iconCache.set(proc.name, resolved);
+              }
+              icon.src = resolved;
+            })
+            .catch(() => {
+              icon.src = DEFAULT_PROCESS_ICON;
+            });
+        }
         item.addEventListener('dragstart', (e) => {
           state.mappingDragActive = true;
           state.mappingDragPayload = { name: proc.name };

--- a/Software/VolumeMaster-Windows/src/renderer/sources.js
+++ b/Software/VolumeMaster-Windows/src/renderer/sources.js
@@ -1,7 +1,6 @@
-import { VM_CHANNELS } from './voicemeeter.js';
 import { state } from './state.js';
-
-const DEFAULT_PROCESS_ICON = 'assets/icons/default.png';
+import { sanitizeAppName } from './utils.js';
+import { VM_CHANNELS } from './voicemeeter.js';
 
 export async function loadProcessList() {
   state.runningProcesses = await window.api.listProcesses();
@@ -41,59 +40,17 @@ export function renderProcessSearch() {
     state.runningProcesses
       .filter((proc) => {
         if (!proc || !proc.name) return false;
-        const title = typeof proc.title === 'string' ? proc.title : '';
-        const matchesSearch =
-          proc.name.toLowerCase().includes(searchFilter) || title.toLowerCase().includes(searchFilter);
+        const matchesSearch = proc.name.toLowerCase().includes(searchFilter);
         const matchesType = typeFilter === 'all' || (typeFilter === 'gui' && proc.isGUI);
         return matchesSearch && matchesType;
       })
       .forEach((proc) => {
         const item = document.createElement('div');
+        item.textContent = (typeof proc.title === 'string' && proc.title.trim()) ? proc.title.trim() : sanitizeAppName(proc.name);
         item.id = `process-item-${proc.name}`;
         item.className =
-          'flex items-center gap-2 px-2 py-1 bg-slate-700 text-indigo-200 rounded cursor-move hover:bg-indigo-600 transition overflow-hidden max-h-12 min-w-0';
+          'px-2 py-1 bg-slate-700 text-indigo-200 rounded cursor-move hover:bg-indigo-600 transition whitespace-nowrap capitalize max-h-8';
         item.setAttribute('draggable', 'true');
-
-        const icon = document.createElement('img');
-        const processTitle = typeof proc.title === 'string' && proc.title.trim() ? proc.title.trim() : proc.name;
-        icon.alt = processTitle;
-        icon.className = 'w-4 h-4 shrink-0 rounded';
-        icon.draggable = false;
-        icon.src = DEFAULT_PROCESS_ICON;
-
-        const textWrap = document.createElement('div');
-        textWrap.className = 'flex flex-col min-w-0 leading-tight';
-
-        const title = document.createElement('span');
-        title.className = 'text-[10px] font-semibold truncate';
-        title.textContent = processTitle;
-
-        const subtitle = document.createElement('span');
-        subtitle.className = 'text-xs text-slate-300 truncate';
-        subtitle.textContent = proc.name;
-
-        textWrap.append(title, subtitle);
-        item.append(icon, textWrap);
-
-        const iconKey = proc.path || proc.name;
-        const cachedIcon = state.iconCache.get(iconKey) || state.iconCache.get(proc.name);
-        if (cachedIcon) {
-          icon.src = cachedIcon;
-        } else {
-          window.api
-            .getAppIcon(iconKey)
-            .then((src) => {
-              const resolved = src || DEFAULT_PROCESS_ICON;
-              state.iconCache.set(iconKey, resolved);
-              if (iconKey === proc.name) {
-                state.iconCache.set(proc.name, resolved);
-              }
-              icon.src = resolved;
-            })
-            .catch(() => {
-              icon.src = DEFAULT_PROCESS_ICON;
-            });
-        }
         item.addEventListener('dragstart', (e) => {
           state.mappingDragActive = true;
           state.mappingDragPayload = { name: proc.name };

--- a/Software/VolumeMaster-Windows/src/renderer/utils.js
+++ b/Software/VolumeMaster-Windows/src/renderer/utils.js
@@ -1,3 +1,17 @@
+import { state } from './state.js';
+
 export function sanitizeAppName(name) {
   return name.replace(/([A-Z]+)/g, ' $1').replace('.exe', '').trim();
+}
+
+export function getProcessDisplayInfo(appName) {
+  const rawName = typeof appName === 'string' ? appName.trim() : '';
+  const running = state.runningProcesses.find(
+    (proc) => typeof proc?.name === 'string' && proc.name.toLowerCase() === rawName.toLowerCase()
+  );
+  const title = typeof running?.title === 'string' ? running.title.trim() : '';
+  return {
+    title,
+    subtitle: rawName,
+  };
 }


### PR DESCRIPTION
This pull request enhances how running processes are listed and displayed in the application, adding richer metadata (like process title and executable path) and improving the user interface for process selection and display. The main changes include updating the process listing APIs for both Windows and macOS, improving UI responsiveness, and displaying friendlier process titles throughout the app.

**Process Metadata and API Enhancements**
- The process listing API for both Windows and macOS now returns additional metadata for each process: `title`, `path`, and a more accurate `isGUI` flag. The Windows implementation uses PowerShell with JSON output and a new `normalizeProcessTitle` helper to derive user-friendly titles, while the macOS implementation provides default values for the new fields. [[1]](diffhunk://#diff-4fe3df306b692790e93afd605ee7132c7f6cfed12a98b1f99122d2c63173b005L8-R8) [[2]](diffhunk://#diff-8fdca172e3b77c1f8d871093b92e3fe16373ea42b071a24965a2bf5ee1e87844L12-R12) [[3]](diffhunk://#diff-8fdca172e3b77c1f8d871093b92e3fe16373ea42b071a24965a2bf5ee1e87844L33-R33) [[4]](diffhunk://#diff-7b0f8f01fbaac749843c1bafb5ec871bc66f88eab4f3c0f17781793660f4c9b5R11-R65)

**User Interface Improvements**
- The app window is now larger by default, with a minimum size set for improved usability on larger screens.
- A new responsive design hides large app icons on smaller screens and adjusts spacing for better mobile and tablet usability.

**Process Display Logic**
- The renderer uses a new `getProcessDisplayInfo` utility to consistently show process titles and subtitles in the UI, making process cards and search items more informative and user-friendly. [[1]](diffhunk://#diff-09b4b039d2a259e12370a39346f8f6b4b619f1af5f2444f35c9d9077e21ee0faL3-R3) [[2]](diffhunk://#diff-09b4b039d2a259e12370a39346f8f6b4b619f1af5f2444f35c9d9077e21ee0faR357-R381) [[3]](diffhunk://#diff-a6ed949f086ebc4767021998606c1ee6a59fafee3c74e5e97b00aa83664e589fL49-R49) [[4]](diffhunk://#diff-4713974224ed950f3d59c09f3c355cc6c577ddbf9a97209c73a20a579ddb6130R1-R17)

Old: 

<img width="1437" height="997" alt="image" src="https://github.com/user-attachments/assets/2656fcab-c3d4-4e4f-a2d9-18ed21309a15" />

New:

<img width="1470" height="793" alt="image" src="https://github.com/user-attachments/assets/a470aa69-fd1e-482f-9ffc-63c6ae053b83" />

Tested on Windows, not on MacOS.